### PR TITLE
Add Bootstrap utility class to fix alert-link color

### DIFF
--- a/adventure/app.js
+++ b/adventure/app.js
@@ -141,7 +141,7 @@ server.post("/user/login", urlencodedParser, function (req, res) {
                     sitePages: sitePages,
                     user: req.user,
                     
-                    message: "Your password was stored in an insecure way - you need to <a href='/user/edit'>update it</a>."
+                    message: "Your password was stored in an insecure way - you need to <a href='/user/edit' class='alert-link'>update it</a>."
                 });
             }
         });


### PR DESCRIPTION
Links in a Bootstrap alert should contain the `class="alert-link"` attribute so that they aren't the default blue. See https://v4-alpha.getbootstrap.com/components/alerts/ for more info.